### PR TITLE
Rename references to `masih` now that repo is transferred

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ Thank you for your interest in contributing to Boostly! Your efforts will help m
 
 2. **Clone Your Fork**: Open a terminal and run:
    ```
-   git clone https://github.com/masih/boostly.git
+   git clone https://github.com/filecoin-shipyard/boostly.git
    ```
 
 3. **Add the Upstream Remote**: This will be useful to sync your fork with the latest changes:
    ```
-   git remote add upstream https://github.com/masih/boostly.git
+   git remote add upstream https://github.com/filecoin-shipyard/boostly.git
    ```
 
 4. **Create a New Branch**: Always base your work on a new branch:
@@ -54,7 +54,7 @@ Thank you for your interest in contributing to Boostly! Your efforts will help m
 
 ## Feedback
 
-If you're unsure about any aspect of the contribution process, please open an [issue](https://github.com/masih/boostly/issues). We're here to help!
+If you're unsure about any aspect of the contribution process, please open an [issue](https://github.com/filecoin-shipyard/boostly/issues). We're here to help!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Boostly 
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/masih/boostly.svg)](https://pkg.go.dev/github.com/masih/boostly)
-[![Go Test](https://github.com/masih/boostly/actions/workflows/go-test.yml/badge.svg)](https://github.com/masih/boostly/actions/workflows/go-test.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/filecoin-shipyard/boostly.svg)](https://pkg.go.dev/github.com/filecoin-shipyard/boostly)
+[![Go Test](https://github.com/filecoin-shipyard/boostly/actions/workflows/go-test.yml/badge.svg)](https://github.com/filecoin-shipyard/boostly/actions/workflows/go-test.yml)
 
 > [Filecoin Boost](https://github.com/filecoin-project/boost) Client Library in Go
 
@@ -16,7 +16,7 @@ Boostly is a lightweight and efficient Go client library for [Filecoin Boost](ht
 ## Installation
 
 ```bash
-go get github.com/masih/boostly@latest
+go get github.com/filecoin-shipyard/boostly@latest
 ```
 
 ## Status
@@ -27,7 +27,7 @@ Please be aware that while we strive to keep the master branch stable, breaking 
 
 ## Documentation
 
-For detailed usage and integration guidance, please refer to [godoc documentation](https://pkg.go.dev/github.com/masih/boostly).
+For detailed usage and integration guidance, please refer to [godoc documentation](https://pkg.go.dev/github.com/filecoin-shipyard/boostly).
 
 ## Resources
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/masih/boostly
+module github.com/filecoin-shipyard/boostly
 
 go 1.20
 


### PR DESCRIPTION
Rename references to `masih` now that repo is moved to `filecoin-shipyard` org.