### PR TITLE
Rename `DealParams` and `DealResponse` to convey relation to "proposal"

### DIFF
--- a/storage_market_cbor_gen.go
+++ b/storage_market_cbor_gen.go
@@ -220,7 +220,7 @@ func (t *StorageAsk) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *DealParams) MarshalCBOR(w io.Writer) error {
+func (t *DealProposal) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -354,8 +354,8 @@ func (t *DealParams) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *DealParams) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = DealParams{}
+func (t *DealProposal) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = DealProposal{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -374,7 +374,7 @@ func (t *DealParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("DealParams: map struct too large (%d)", extra)
+		return fmt.Errorf("DealProposal: map struct too large (%d)", extra)
 	}
 
 	var name string
@@ -718,7 +718,7 @@ func (t *Transfer) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *DealResponse) MarshalCBOR(w io.Writer) error {
+func (t *DealProposalResponse) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -771,8 +771,8 @@ func (t *DealResponse) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *DealResponse) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = DealResponse{}
+func (t *DealProposalResponse) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = DealProposalResponse{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -791,7 +791,7 @@ func (t *DealResponse) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("DealResponse: map struct too large (%d)", extra)
+		return fmt.Errorf("DealProposalResponse: map struct too large (%d)", extra)
 	}
 
 	var name string


### PR DESCRIPTION
`DealParams` in Boost is the struct by which deal proposal configuration is passed onto a SP. The response to it, either acceptance or rejection, is then captured by a struct named `DealResponse`. The original names could be clearer in terms of expressing that they relate to deal proposal negotiation between the SP and a client.

Rename them to `DealProposal` and `DealProposalResponse` for better human readability. The struct names has no impact on the wire protocol and this should impose no breaking changes on Boost libp2p protocols.